### PR TITLE
Add mysql-client-core-8.0 to enable mysqldump

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,4 +14,4 @@ sudo apt-get install dnsutils -y
 sudo apt-get install traceroute -y
 sudo snap install dnslookup
 
-sudo apt install mariadb-client-core-10.6 -y
+sudo apt install mysql-client-core-8.0 -y


### PR DESCRIPTION
While trying to get a DB dump an error was encountered:

-----
Command 'mysqldump' not found, but can be installed with: apt install mysql-client-core-8.0  # version 8.0.39-0ubuntu0.22.04.1, or
apt install mariadb-client-10.6    # version 1:10.6.18-0ubuntu0.22.04.1
-----

AS we're using RDS MySQL using the MySQL client as suggested will include the mysqldump command.

ND-510